### PR TITLE
Add a fallback to `electron` package

### DIFF
--- a/lib/karma-electron-launcher.js
+++ b/lib/karma-electron-launcher.js
@@ -1,11 +1,22 @@
 // Load in our dependencies
 // DEV: We use `require`/`assert` instead of `peerDependencies` to make floating dependencies easier
 var electronPrebuilt;
-try {
+
+function moduleExists(moduleName) {
+  try {
+    return require.resolve(moduleName);
+  } catch (err) {
+    return false;
+  }
+}
+
+if (moduleExists('electron-prebuilt')) {
   electronPrebuilt = require('electron-prebuilt');
-} catch (err) {
-  console.error('Expected `electron-prebuilt` to be installed but it was not. Please install it.');
-  throw err;
+  console.warn('WARN: Consider changing from `electron-prebuilt` to `electron` has it will be deprecated soon.');
+} else if (moduleExists('electron')) {
+  electronPrebuilt = require('electron');
+} else {
+  throw new Error('Expected an electron package to be installed but none was found. Please install `electron`.');
 }
 
 // DEV: This is a trimmed down version of https://github.com/karma-runner/karma-chrome-launcher/blob/v0.2.2/index.js


### PR DESCRIPTION
Also add a warning considering `electron-prebuilt` will be deprecated in the end of 2016.

Note: The tests were failing before I made any changes.
