### PR TITLE
Upcoming Change in Electron 17: Removed: desktopCapturer.getSources in the renderer

### DIFF
--- a/lib/electron-launcher.js
+++ b/lib/electron-launcher.js
@@ -14,7 +14,7 @@ var async = require('async');
 var BrowserWindow = electron.BrowserWindow;
 var program = require('commander');
 
-// restore desktopCapturer.getSources to the renderer process
+// Restore access to desktopCapturer.getSources to the renderer process
 // https://www.electronjs.org/docs/latest/breaking-changes#default-changed-contextisolation-defaults-to-true
 electron.ipcMain.handle(
   'DESKTOP_CAPTURER_GET_SOURCES',

--- a/lib/electron-launcher.js
+++ b/lib/electron-launcher.js
@@ -5,13 +5,21 @@ process.on('uncaughtException', function handleUncaughtException (err) {
 });
 
 // Load in our dependencies
+var electron = require('electron');
 var assert = require('assert');
 var fs = require('fs');
 var path = require('path');
-var app = require('electron').app;
+var app = electron.app;
 var async = require('async');
-var BrowserWindow = require('electron').BrowserWindow;
+var BrowserWindow = electron.BrowserWindow;
 var program = require('commander');
+
+// restore desktopCapturer.getSources to the renderer process
+// https://www.electronjs.org/docs/latest/breaking-changes#default-changed-contextisolation-defaults-to-true
+electron.ipcMain.handle(
+  'DESKTOP_CAPTURER_GET_SOURCES',
+  (event, opts) => electron.desktopCapturer.getSources(opts),
+);
 
 // Set up our CLI parser
 program.name = 'electron-launcher';


### PR DESCRIPTION
### Info on this PR
According to the [Electron Docs](https://www.electronjs.org/docs/latest/breaking-changes#removed-desktopcapturergetsources-in-the-renderer), `desktopCapturer.getSources` will only be available in the main process and will need to be exposed through IPC before being used in a renderer process. In order to test functions which depend on desktopCapturer.getSources in karma, the appropriate handler has to be created in the launcher.

To access `desktopCapturer.getSources` in a renderer process, an accompanying preload script containing the following needs to be added.
```javascript
const { ipcRenderer } = require('electron')

const desktopCapturer = {
  getSources: (opts) => ipcRenderer.invoke('DESKTOP_CAPTURER_GET_SOURCES', opts)
}
```

This PR is changing up the dependencies for readability to DRY code. It adds the event emitter listening for 'DESKTOP_CAPTURER_GET_SOURCES' which will allow testers to use the `desktopCapturer.getSources` method if needed.

### How to Test
Normal regression testing, I'm not sure about your process. You could also fire up karma with different Electron versions and run the following in the developer console. You should get some active windows and screens available for screen-sharing.
```javascript
window.electron.desktopCapturer.getSources({ types: ['window', 'screen'] }).then(async sources => {
    for (const source of sources) {
        console.log('source: ', source.name)
    }
});
```

### Issue Being Resolved
See [this upcoming, breaking change](https://www.electronjs.org/docs/latest/breaking-changes#removed-desktopcapturergetsources-in-the-renderer).