### PR TITLE
Add support to enableRemoteModule for electron >= 14

### DIFF
--- a/lib/electron-launcher.js
+++ b/lib/electron-launcher.js
@@ -91,6 +91,12 @@ async.parallel([
   if (program.show !== undefined) {
     browserWindowOptions.show = !!program.show;
   }
+  if (browserWindowOptions.webPreferences.enableRemoteModule) {
+    require('@electron/remote/main').initialize();
+    app.on('browser-window-created', function (_, window) {
+      require('@electron/remote/main').enable(window.webContents);
+    });
+  }
   var browserWindow = new BrowserWindow(browserWindowOptions);
   // Pass along same options to children (e.g. show), https://github.com/twolfson/karma-electron/issues/54
   // https://github.com/electron/electron/blob/v12.1.2/docs/api/window-open.md#native-window-example

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "xtend": "~4.0.1"
   },
   "devDependencies": {
+    "@electron/remote": "^2.0.8",
     "collections": "~3.0.0",
     "cross-env": "~1.0.7",
     "electron": "~20.0.2",


### PR DESCRIPTION
This PR gives the possibility to use karma-electron with electron >= 14 when using remote in renderer process.
This adds @electron/remote@2 dependency and the appropriate calls to enable remote in browserWindow webContents when creating them.

See https://github.com/electron/remote/blob/main/docs/migration-2.md
